### PR TITLE
feat: add /arbitraje command using arbitrage service

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ const { Telegraf } = require('telegraf');
 const { loadConfig } = require('./config');
 const tonService = require('./services/tonService');
 const planetixService = require('./services/planetixService');
+const arbitrageService = require('./services/arbitrageService');
+
 
 // Cargar configuración desde variables de entorno
 const config = loadConfig();
@@ -45,10 +47,29 @@ bot.command('ventas', async (ctx) => {
   }
   let msg = 'Ventas recientes:\n';
   for (const sale of sales) {
-    msg += `• ${sale.platform.toUpperCase()}: ${sale.asset} vendido por ${sale.price} ${sale.currency}\n`;
+
+             msg += `• ${sale.platform.toUpperCase()}: ${sale.asset} vendido por ${sale.price} ${sale.currency}\n`;
   }
   ctx.reply(msg);
 });
+
+// Comando /arbitraje: muestra oportunidades de arbitraje
+bot.command('arbitraje', async (ctx) => {
+    try {
+          const opportunities = await arbitrageService.getArbitrageOpportunities();
+          if (!opportunities || opportunities.length === 0) {
+                  ctx.reply('No hay oportunidades de arbitraje en este momento.');
+                  return;
+                }
+          let message = 'Oportunidades de arbitraje:\n';
+          for (const opp of opportunities) {
+                  message += `${opp.pair}: Dex: ${opp.dexPrice} CEX: ${opp.cexPrice} Profit: ${opp.profitPct}\n`;
+                }
+          ctx.reply(message);
+        } catch (e) {
+          ctx.reply('Error al obtener oportunidades de arbitraje.');
+        }
+  });
 
 // Funcíón de notificación centralizada
 async function notify(message) {

--- a/services/arbitrageService.js
+++ b/services/arbitrageService.js
@@ -1,0 +1,22 @@
+const axios = require('axios');
+
+// Sample function to fetch arbitrage opportunities. In a real implementation, it would fetch price data from APIs.
+async function getArbitrageOpportunities() {
+  // For demonstration, return some dummy arbitrage opportunities between DEX and CEX
+  return [
+    {
+      pair: 'ETH/USDT',
+      dexPrice: '2000',
+      cexPrice: '2050',
+      profitPct: '2.5%'
+    },
+    {
+      pair: 'BTC/USDT',
+      dexPrice: '30000',
+      cexPrice: '30300',
+      profitPct: '1%'
+    }
+  ];
+}
+
+module.exports = { getArbitrageOpportunities };


### PR DESCRIPTION
This pull request introduces a new arbitrage module and a corresponding /arbitraje command.

- Adds `services/arbitrageService.js` which provides a function to fetch arbitrage opportunities. It currently returns static sample data and can be extended later.
- Updates `index.js` to import the arbitrage service and register the /arbitraje command. The command displays available arbitrage opportunities, or notifies if none are available.

These additions extend the bot's functionality to monitor price differences between DEX and CEX and inform users of potential arbitrage trades.